### PR TITLE
Refactor Observer and Subject to support variadic templates

### DIFF
--- a/Observer.h
+++ b/Observer.h
@@ -7,79 +7,8 @@
 template <class T, class... U> class Subject;
 template <class T, class... U> class Observer;
 
-template <class T>
-class AutoCleanup {
-
-	public:
-
-		virtual ~AutoCleanup() = default;
-
-		bool addReference(std::weak_ptr<T> ref) {
-			if (auto target = ref.lock()) {
-				auto it = std::find_if(mReferences.begin(), mReferences.end(), [&target](const auto& weakRef) {
-					auto ptr = weakRef.lock();
-					return ptr && ptr == target;
-				});
-
-				if (it == mReferences.end()) {
-					mReferences.push_back(target);
-					return true;
-				}
-			}
-
-			return false;
-		}
-
-		bool removeReference(std::weak_ptr<T> object) {
-			if (auto targetObject = object.lock()) {
-				const std::size_t oldSize = mReferences.size();
-				mReferences.erase(
-					std::remove_if(mReferences.begin(), mReferences.end(), [&targetObject](const auto& weakObject) {
-						auto ptr = weakObject.lock();
-						return !ptr || ptr == targetObject;
-					}),
-					mReferences.end()
-				);
-
-				return mReferences.size() < oldSize;
-			}
-
-			return false;
-		}
-	
-		void clearExpired() {
-			mReferences.erase(
-				std::remove_if(mReferences.begin(), mReferences.end(), [](const auto& weakObs) {
-					return weakObs.expired();
-				}),
-				mReferences.end()
-			);
-		}
-
-
-		template <class F, class... Args>
-		void callOnValidRefs(F&& func, Args&&... args) {
-			for (const auto& weakRef : mReferences)
-				if (auto ref = weakRef.lock())
-					(ref.get()->*func)(std::forward<Args>(args)...);
-		}
-
-
-		auto begin() { return mReferences.begin(); }
-		auto end() { return mReferences.end(); }
-		auto begin() const { return mReferences.begin(); }
-		auto end() const { return mReferences.end(); }
-
-
-	private:
-
-		std::vector<std::weak_ptr<T>> mReferences;
-
-};
-
-
 template <class T, class... U>
-class Observer: public std::enable_shared_from_this<Observer<T, U...>> {
+class Observer {
 
 	public:
 
@@ -91,15 +20,20 @@ class Observer: public std::enable_shared_from_this<Observer<T, U...>> {
 
 template <class T, class... U>
 class Subject: public std::enable_shared_from_this<Subject<T, U...>> {
-	using Obs = Observer<T, U...>;
+	friend class Subject<void>;
+
+	using _Observer = Observer<T, U...>;
+	using _WeakObserver = std::weak_ptr<_Observer>;
+	using _SharedObserver = std::shared_ptr<_Observer>;
+
 
 	public:
 
-		void registerObserver(std::shared_ptr<Obs> observer) {
+		void registerObserver(std::shared_ptr<Observer<T, U...>> observer) {
 			mObservers.addReference(observer);
 		}
 
-		void removeObserver(std::shared_ptr<Obs> observer) {
+		void removeObserver(std::shared_ptr<Observer<T, U...>> observer) {
 			mObservers.removeReference(observer);
 		}
 
@@ -108,24 +42,91 @@ class Subject: public std::enable_shared_from_this<Subject<T, U...>> {
 
 		virtual void notifyAll(const T& data, const U&... other) {
 			mObservers.clearExpired();
-			
-			for (const auto& weakObs : mObservers)
-				if (auto observer = weakObs.lock())
-					observer->update(data, other...);
-
+			mObservers.callOnValidRefs(&_Observer::update, data, other...);
 		}
 
 
-	protected:
+	private:
+
+		template <class _T>
+		struct AutoCleanup {
+			
+			using _WrappedType = std::weak_ptr<_T>;
+
+			public:
+
+				bool addReference(_WrappedType ref) {
+					if (auto target = ref.lock()) {
+						auto it = std::find_if(mReferences.begin(), mReferences.end(), [&target](const auto& weakRef) {
+							auto ptr = weakRef.lock();
+							return ptr && ptr == target;
+											   });
+
+						if (it == mReferences.end()) {
+							mReferences.push_back(target);
+							return true;
+						}
+					}
+
+					return false;
+				}
+
+				bool removeReference(_WrappedType object) {
+					if (auto targetObject = object.lock()) {
+						const std::size_t oldSize = mReferences.size();
+						mReferences.erase(
+							std::remove_if(mReferences.begin(), mReferences.end(), [&targetObject](const auto& weakObject) {
+								auto ptr = weakObject.lock();
+								return !ptr || ptr == targetObject;
+										   }),
+							mReferences.end()
+						);
+
+						return mReferences.size() < oldSize;
+					}
+
+					return false;
+				}
+
+				void clearExpired() {
+					mReferences.erase(
+						std::remove_if(mReferences.begin(), mReferences.end(), [](const auto& weakObs) {
+							return weakObs.expired();
+									   }),
+						mReferences.end()
+					);
+				}
+
+
+				template <class F, class... Args>
+				void callOnValidRefs(F&& func, Args&&... args) {
+					for (const auto& weakRef : mReferences)
+						if (auto ref = weakRef.lock())
+							(ref.get()->*func)(std::forward<Args>(args)...);
+				}
+
+
+				auto begin() { return mReferences.begin(); }
+				auto end() { return mReferences.end(); }
+				auto begin() const { return mReferences.begin(); }
+				auto end() const { return mReferences.end(); }
+
+
+			private:
+
+				std::vector<_WrappedType> mReferences;
+
+		};
+
+
+	public:
 		
-		AutoCleanup<Obs> mObservers;
+		AutoCleanup<_Observer> mObservers;
 
 };
 
-
-
 template <>
-class Observer<void>: public std::enable_shared_from_this<Observer<void>> {
+class Observer<void> {
 
 	public:
 
@@ -138,7 +139,7 @@ class Observer<void>: public std::enable_shared_from_this<Observer<void>> {
 
 template <>
 class Subject<void>: public std::enable_shared_from_this<Subject<void>> {
-
+	using _Observer = Observer<void>;
 
 	public:
 
@@ -151,25 +152,21 @@ class Subject<void>: public std::enable_shared_from_this<Subject<void>> {
 		}
 
 
-		protected:
+	protected:
 
 		virtual void notifyAll() {
 			mObservers.clearExpired();
-
-			for (const auto& weakObs : mObservers)
-				if (auto observer = weakObs.lock())
-					observer->update();
-
+			mObservers.callOnValidRefs(&Observer<void>::update);
 		}
 
 
 	protected:
 
-		AutoCleanup<Observer<void>> mObservers;
+		// Dummy template argument to access AutoCleanup
+		Subject<int>::AutoCleanup<_Observer> mObservers;
 
 };
 
 
 using SimpleSubject = Subject<void>;
 using SimpleObserver = Observer<void>;
-

--- a/main.cpp
+++ b/main.cpp
@@ -10,7 +10,7 @@ void example1() {
 			}
 	};
 
-	class View: public simpleObserver {
+	class View: public SimpleObserver {
 		public:
 			void update() override {
 				std::cout << "View: updated\n";


### PR DESCRIPTION
Refactored `Observer` and `Subject` classes to support variadic templates, enabling them to handle multiple types. 
Integrated `AutoCleanup` as a private nested struct within `Subject`, preserving its functionality with the new template parameters. Updated `Observer<void>` and `Subject<void>` specializations to use the new `AutoCleanup` mechanism.